### PR TITLE
Set env var

### DIFF
--- a/templates/alloy-deployment.yaml
+++ b/templates/alloy-deployment.yaml
@@ -35,6 +35,18 @@ spec:
           env:
             - name: ALLOY_NATS_CREDS_FILE
               value: /etc/nats/nats.creds
+            - name: SERVERSERVICE_ENDPOINT
+              value: "{{ .Values.alloy.env.SERVERSERVICE_ENDPOINT }}"
+            - name: SERVERSERVICE_SKIP_OAUTH
+              value: "{{ .Values.alloy.env.SERVERSERVICE_SKIP_OAUTH }}"
+            - name: SERVERSERVICE_FACILITY_CODE
+              value: "{{ .Values.alloy.env.SERVERSERVICE_FACILITY_CODE }}"
+            - name: ALLOY_NATS_URL
+              value: "{{ .Values.alloy.env.ALLOY_NATS_URL }}"
+            - name: ALLOY_NATS_STREAM_USER
+              value: "{{ .Values.alloy.env.ALLOY_NATS_STREAM_USER }}"
+            - name: ALLOY_NATS_STREAM_PASS
+              value: "{{ .Values.alloy.env.ALLOY_NATS_STREAM_PASS }}"
           resources:
             limits:
               cpu: 200m


### PR DESCRIPTION
Environments variables set in the `values.yaml` are not used in `alloy-deployment.yaml`.
This PR read those variables from values.yaml and set env vars.