### PR TITLE
update-alloy-deployment-flags

### DIFF
--- a/templates/alloy-deployment.yaml
+++ b/templates/alloy-deployment.yaml
@@ -20,12 +20,10 @@ spec:
           command: [
            "alloy",
            "outofband",
-           "--store",
-           "serverservice",
-           "--controller-mode",
-           "--config",
+           "--asset-source",
+           "serverService",
+           "--config-file",
            "/etc/alloy/config.yaml",
-           "--enable-pprof",
           ]
           volumeMounts:
             - name: config-volume


### PR DESCRIPTION
Pod fails to start while running the sandbox. The pod error shows
```
flag provided but not defined: -store
flag provided but not defined: -controller-mode
flag provided but not defined: -config
```

Remove `-controller-mode` and `-enable-pprof`
Update `-store=serverservice` to `-asset-source=serverService`
Update `-config` to `config-file`