### PR TITLE
Fix base64 wrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.tar.gz
 values-nats.yaml
 scripts/serverservice/add-server
+.idea

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This chart deploys the various metal-toolbox/hollow services in docker KIND for 
 
  - [Serverservice](https://github.com/metal-toolbox/hollow-serverservice) with the CrDB backend.
  - [Conditionorc](https://github.com/metal-toolbox/conditionorc)
- - [Alloy](https://github.com/metal-toolbox/alloy)
+ - [Alloy](https://github.com/metal-toolbox/alloy/tree/v2) (v2 branch)
  - [Flasher](https://github.com/metal-toolbox/flasher/)
  - NATS Jetstream and K/V
  - Chaos mesh
@@ -27,7 +27,7 @@ Clone each of the repositories and run `make push-image-devel`
 
  - [Serverservice](https://github.com/metal-toolbox/hollow-serverservice)
  - [Conditionorc](https://github.com/metal-toolbox/conditionorc)
- - [Alloy](https://github.com/metal-toolbox/alloy)
+ - [Alloy](https://github.com/metal-toolbox/alloy/tree/v2) (v2 branch)
  - [Flasher](https://github.com/metal-toolbox/flasher/)
 
 This will build and push the container images to the local container registry.


### PR DESCRIPTION
Made some minor improvements based on some issue I had with initial use.

- Disable line wrapping from base64 when creating secrets, and removed some code duplication.
- Specify the alloy v2 branch in the README.