### PR TITLE
Update sandbox config and crdb version

### DIFF
--- a/templates/alloy-deployment.yaml
+++ b/templates/alloy-deployment.yaml
@@ -20,13 +20,10 @@ spec:
           command: [
            "alloy",
            "outofband",
-           "--worker",
-           "--config",
+           "--config-file",
            "/etc/alloy/config.yaml",
-           "--facility-code",
-           "{{ .Values.location }}",
-           "--replica-count",
-           "1"
+           "--asset-source",
+           "serverService",
           ]
           volumeMounts:
             - name: config-volume
@@ -35,25 +32,27 @@ spec:
               mountPath: /etc/nats
               readOnly: true
           env:
-            - name: ALLOY_SERVERSERVICE_ENDPOINT
+            - name: SERVERSERVICE_ENDPOINT
               value: "{{ .Values.alloy.env.SERVERSERVICE_ENDPOINT }}"
-            - name: ALLOY_SERVERSERVICE_DISABLE_OAUTH
+            - name: SERVERSERVICE_SKIP_OAUTH
               value: "{{ .Values.alloy.env.SERVERSERVICE_DISABLE_OAUTH }}"
-            - name: ALLOY_SERVERSERVICE_FACILITY_CODE
+            - name: SERVERSERVICE_FACILITY_CODE
               value: "{{ .Values.alloy.env.SERVERSERVICE_FACILITY_CODE }}"
-            - name: ALLOY_NATS_URL
-              value: "{{ .Values.alloy.env.ALLOY_NATS_URL }}"
-            - name: ALLOY_NATS_CREDS_FILE
+            - name: SERVERSERVICE_FACILITY_CODE
+              value: "{{ .Values.alloy.env.SERVERSERVICE_FACILITY_CODE }}"
+            - name: NATS_URL
+              value: "{{ .Values.alloy.env.NATS_URL }}"
+            - name: NATS_CREDS_FILE
               value: /etc/nats/nats.creds
-            - name: ALLOY_NATS_CONNECT_TIMEOUT
+            - name: NATS_CONNECT_TIMEOUT
               value: "{{ .Values.flasher.env.NATS_CONNECT_TIMEOUT }}"
-            - name: ALLOY_NATS_CONSUMER_NAME
+            - name: NATS_CONSUMER_NAME
               value: "{{ .Values.location }}-alloy"
-            - name: ALLOY_NATS_CONSUMER_SUBSCRIBESUBJECTS
+            - name: NATS_CONSUMER_SUBSCRIBESUBJECTS
               value: "com.hollow.sh.controllers.commands.{{ .Values.location }}.servers.inventory"
-            - name: ALLOY_NATS_CONSUMER_FILTERSUBJECT
+            - name: NATS_CONSUMER_FILTERSUBJECT
               value: "com.hollow.sh.controllers.commands.{{ .Values.location }}.servers.inventory"
-            - name: ALLOY_NATS_PUBLISHERSUBJECTPREFIX
+            - name: NATS_PUBLISHERSUBJECTPREFIX
               value: "com.hollow.sh.controllers.responses.{{ .Values.location }}.servers.inventory"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "{{ .Values.alloy.env.OTEL_EXPORTER_OTLP_ENDPOINT }}"

--- a/templates/conditionorc-orchestrator-deployment.yaml
+++ b/templates/conditionorc-orchestrator-deployment.yaml
@@ -23,7 +23,6 @@ spec:
             - "/etc/conditionorc/config.yaml"
             - "--log-level"
             - "debug"
-            - "--replica-count=1"
             - "--facility"
             - "{{ .Values.location }}"
           ports:

--- a/templates/crdb-deployment.yaml
+++ b/templates/crdb-deployment.yaml
@@ -22,7 +22,7 @@ spec:
             # https://github.com/cockroachdb/cockroach/issues/81209
             - name: COCKROACH_RAFT_CLOSEDTS_ASSERTIONS_ENABLED
               value: "false"
-          image: cockroachdb/cockroach:latest-v21.1
+          image: cockroachdb/cockroach:v23.1.11
           args:
             - start-single-node
             - --insecure

--- a/values.yaml
+++ b/values.yaml
@@ -63,7 +63,7 @@ alloy:
     OTEL_EXPORTER_OTLP_ENDPOINT: jaeger:4317
     OTEL_EXPORTER_OTLP_INSECURE: true
 crdb:
-  image: cockroachdb/cockroach:latest-v21.1
+  image: cockroachdb/cockroach:v23.1.11
 
 chaos-mesh:
   enabled: false


### PR DESCRIPTION
Upgrade sandbox configuration to match latest component changes(eg, we are using `SERVERSERVICE_SKIP_OAUTH` instead of `SERVERSERVICE_DISABLE_OAUTH`)

It also makes more sense to use the same CRDB version as production.