### PR TITLE
Update cockroachdb image to v23.1.11

### DIFF
--- a/templates/crdb-deployment.yaml
+++ b/templates/crdb-deployment.yaml
@@ -22,7 +22,7 @@ spec:
             # https://github.com/cockroachdb/cockroach/issues/81209
             - name: COCKROACH_RAFT_CLOSEDTS_ASSERTIONS_ENABLED
               value: "false"
-          image: cockroachdb/cockroach:latest-v21.1
+          image: cockroachdb/cockroach:v23.1.11
           args:
             - start-single-node
             - --insecure


### PR DESCRIPTION
The version used by sandbox (v21.1) is out of support.

Version support documented here:
https://www.cockroachlabs.com/docs/releases/release-support-policy

This change updates the version to the same version deployed in fleet-crdb (v23.1.11).