### PR TITLE
Revert "Update cockroachdb image to v23.1.11 (#40)"

### DIFF
--- a/templates/crdb-deployment.yaml
+++ b/templates/crdb-deployment.yaml
@@ -22,7 +22,7 @@ spec:
             # https://github.com/cockroachdb/cockroach/issues/81209
             - name: COCKROACH_RAFT_CLOSEDTS_ASSERTIONS_ENABLED
               value: "false"
-          image: cockroachdb/cockroach:v23.1.11
+          image: cockroachdb/cockroach:latest-v21.1
           args:
             - start-single-node
             - --insecure


### PR DESCRIPTION
This reverts commit 3150d7533deaabbef658981163558dc89a5459a7.

Apparently the never version of CockroachDB is causing problems with some of the database migrations in serverservice. Reverting this PR for now.