### PR TITLE
[WIP] Upgrade crdb from v21.1 to v23.1.11

### DIFF
--- a/templates/crdb-deployment.yaml
+++ b/templates/crdb-deployment.yaml
@@ -22,7 +22,7 @@ spec:
             # https://github.com/cockroachdb/cockroach/issues/81209
             - name: COCKROACH_RAFT_CLOSEDTS_ASSERTIONS_ENABLED
               value: "false"
-          image: cockroachdb/cockroach:latest-v21.1
+          image: cockroachdb/cockroach:v23.1.11
           args:
             - start-single-node
             - --insecure

--- a/values.yaml
+++ b/values.yaml
@@ -86,7 +86,7 @@ syncer:
     SYNCER_GITHUB_OPENBMC_TOKEN: redacted
 
 crdb:
-  image: cockroachdb/cockroach:latest-v21.1
+  image: cockroachdb/cockroach:latest-v23.1.11
 
 chaos-mesh:
   enabled: false


### PR DESCRIPTION
This PR may be closed if we are not able to make crdb v23.1.11 compatible with serverservice.

If so, we still need to keep existing v21.1 for running serverservice in sandbox,
and run a new v23.1.1 for running fleetdb in sandbox.