### PR TITLE
fs-1078; Makefile cleanup and additional features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,18 @@
 .DEFAULT_GOAL := help
 
+CONDITION_ORC_PORT=9001
+ALLOY_PORT=9091
+HSS_PORT=8000
+CRDB_PORT=26257
+CHAOS_DASH_PORT=2333
+JAEGER_DASH_PORT=16686
+MINIO_PORT=9000
+
+# Makefile function. call with $(call,<param1>,<param2>...)
+define forward-port
+		$(if $(filter-out 1,$(FOWARD_TO_LOCAL_NETWORK)),kubectl port-forward $(1) $(2):$(2),kubectl port-forward $(1) --address 0.0.0.0 $(2):$(2))
+endef
+
 ## install helm chart for the sandbox env
 install: kubectl-ctx-kind
 	cp ./scripts/nats-bootstrap/values-nats.yaml.tmpl values-nats.yaml
@@ -20,31 +33,51 @@ clean: kubectl-ctx-kind
 
 ## port forward condition orchestrator API  (runs in foreground)
 port-forward-conditionorc-api: kubectl-ctx-kind
-	kubectl port-forward deployment/conditionorc-api 9001:9001
+	$(call forward-port,deployment/conditionorc-api,${CONDITION_ORC_PORT})
 
 ## port forward condition Alloy pprof endpoint  (runs in foreground)
 port-forward-alloy-pprof: kubectl-ctx-kind
-	kubectl port-forward deployment/alloy 9091:9091
+	$(call forward-port,deployment/alloy,${ALLOY_PORT})
 
 ## port forward hollow server service port (runs in foreground)
 port-forward-hss: kubectl-ctx-kind
-	kubectl port-forward deployment/serverservice 8000:8000
+	$(call forward-port,deployment/serverservice,${HSS_PORT})
 
 ## port forward crdb service port (runs in foreground)
 port-forward-crdb: kubectl-ctx-kind
-	kubectl port-forward deployment/crdb 26257:26257
+	$(call forward-port,deployment/crdb,${CRDB_PORT})
 
 ## port forward chaos-mesh dashboard (runs in foreground)
 port-forward-chaos-dash: kubectl-ctx-kind
-	kubectl port-forward  service/chaos-dashboard 2333:2333
+	$(call forward-port,service/chaos-dashboard,${CHAOS_DASH_PORT})
 
 ## port forward jaeger frontend
 port-forward-jaeger-dash:
-	kubectl port-forward  service/jaeger 16686:16686
+	$(call forward-port,service/jaeger,${JAEGER_DASH_PORT})
 
 ## port forward to the minio S3 port
 port-forward-minio:
-	kubectl port-forward deployment/minio 9000
+	$(call forward-port,deployment/minio,${MINIO_PORT})
+
+## port forward all endpoints (runs in the background)
+port-all:
+	$(MAKE) port-forward-conditionorc-api > /dev/null 2>&1 &\
+	$(MAKE) port-forward-alloy-pprof > /dev/null 2>&1 &		\
+	$(MAKE) port-forward-hss > /dev/null 2>&1 &				\
+	$(MAKE) port-forward-crdb > /dev/null 2>&1 &			\
+	$(MAKE) port-forward-chaos-dash > /dev/null 2>&1 &		\
+	$(MAKE) port-forward-jaeger-dash > /dev/null 2>&1 &		\
+	$(MAKE) port-forward-mino > /dev/null 2>&1 &
+
+## kill all port fowarding processes that are running in the background
+kill-all-ports:
+	lsof -i:${CONDITION_ORC_PORT} -t | xargs kill
+	lsof -i:${ALLOY_PORT} -t | xargs kill
+	lsof -i:${HSS_PORT} -t | xargs kill
+	lsof -i:${CRDB_PORT} -t | xargs kill
+	lsof -i:${CHAOS_DASH_PORT} -t | xargs kill
+	lsof -i:${JAEGER_DASH_PORT} -t | xargs kill
+	lsof -i:${MINIO_PORT} -t | xargs kill
 
 ## install extra services used to test firmware-syncer
 firmware-syncer-env:
@@ -71,7 +104,6 @@ psql-crdb: kubectl-ctx-kind
 ## purge nats app and storage pvcs
 clean-nats:
 	kubectl delete statefulsets.apps nats && kubectl delete pvc nats-js-pvc-nats-0 nats-jwt-pvc-nats-0
-
 #
 ## set kube ctx to kind cluster
 kubectl-ctx-kind:
@@ -85,13 +117,16 @@ YELLOW := $(shell tput -Txterm setaf 3)
 WHITE  := $(shell tput -Txterm setaf 7)
 RESET  := $(shell tput -Txterm sgr0)
 
-
-TARGET_MAX_CHAR_NUM=20
+TARGET_MAX_CHAR_NUM=32
 ## Show help
 help:
 	@echo ''
 	@echo 'Usage:'
 	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo ''
+	@echo 'Flags:'
+	@echo '  ${YELLOW}FOWARD_TO_LOCAL_NETWORK=1${RESET}        ${GREEN}Expand Port forwarding to LAN${RESET}'
+	@echo '  ${YELLOW}FOWARD_TO_LOCAL_NETWORK=0${RESET}        ${GREEN}Disable port forwarding to LAN (DEFAULT)${RESET}'
 	@echo ''
 	@echo 'Targets:'
 	@awk '/^[a-zA-Z\-\\_0-9]+:/ { \


### PR DESCRIPTION
Some QoL stuff I wanted to do to prepare for the actual work that will come a bit later today. So separating it out into two PRs.

Additions to the makefile:
-Moving the port declarations to the top of the makefile
-Flag that allows your portfowarding to exist on your LAN instead of just your machine.
-Moving the port forward to a function (right under the port declarations) to make the LAN enabling feature a bit cleaner
-Make target to just forward all ports and run in background. I got quite annoyed having to have multiple terminals open just to port forward what i needed.
-Make target to kill all port forwarding processes
-Increased the help character max to 32, as it was no longer cleanly printing out the help menu