### PR TITLE
FS-1101; Fleet Scheduler updates and linux support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,72 +37,72 @@ clean: kubectl-ctx-kind
 
 ## port forward condition orchestrator API  (runs in foreground)
 port-forward-conditionorc-api: kubectl-ctx-kind
-	kubectl port-forward deployment/conditionorc-api ${CONDITION_ORC_PORT}:${CONDITION_ORC_PORT}
+	kubectl port-forward deployment/conditionorc-api $(CONDITION_ORC_PORT):$(CONDITION_ORC_PORT)
 
 ## port forward condition Alloy pprof endpoint  (runs in foreground)
 port-forward-alloy-pprof: kubectl-ctx-kind
-	kubectl port-forward deployment/alloy ${ALLOY_PORT}:${ALLOY_PORT}
+	kubectl port-forward deployment/alloy $(ALLOY_PORT):$(ALLOY_PORT)
 
 ## port forward hollow server service port (runs in foreground)
 port-forward-hss: kubectl-ctx-kind
-	kubectl port-forward deployment/serverservice ${HSS_PORT}:${HSS_PORT}
+	kubectl port-forward deployment/serverservice $(HSS_PORT):$(HSS_PORT)
 
 ## port forward fleetdb port (runs in foreground)
 port-forward-fleetdb: kubectl-ctx-kind
-	kubectl port-forward deployment/fleetdb ${HSS_PORT}:${HSS_PORT}
+	kubectl port-forward deployment/fleetdb $(HSS_PORT):$(HSS_PORT)
 
 ## port forward crdb service port (runs in foreground)
 port-forward-crdb: kubectl-ctx-kind
-	kubectl port-forward deployment/crdb ${CRDB_PORT}:${CRDB_PORT}
+	kubectl port-forward deployment/crdb $(CRDB_PORT):$(CRDB_PORT)
 
 ## port forward fleetdb crdb service port (runs in foreground)
 port-forward-fleetdb-crdb: kubectl-ctx-kind
-	kubectl port-forward deployment/fleetdb-crdb ${CRDB_PORT}:${CRDB_PORT}
+	kubectl port-forward deployment/fleetdb-crdb $(CRDB_PORT):$(CRDB_PORT)
 
 ## port forward chaos-mesh dashboard (runs in foreground)
 port-forward-chaos-dash: kubectl-ctx-kind
-	kubectl port-forward service/chaos-dashboard ${CHAOS_DASH_PORT}:${CHAOS_DASH_PORT}
+	kubectl port-forward service/chaos-dashboard $(CHAOS_DASH_PORT):$(CHAOS_DASH_PORT)
 
 ## port forward jaeger frontend
 port-forward-jaeger-dash:
-	kubectl port-forward service/jaeger ${JAEGER_DASH_PORT}:${JAEGER_DASH_PORT}
+	kubectl port-forward service/jaeger $(JAEGER_DASH_PORT):$(JAEGER_DASH_PORT)
 
 ## port forward to the minio S3 port
 port-forward-minio:
-	kubectl port-forward deployment/minio ${MINIO_PORT}:${MINIO_PORT}
+	kubectl port-forward deployment/minio $(MINIO_PORT):$(MINIO_PORT)
 
 ## port forward all endpoints (runs in the background)
 port-all-with-lan:
-	kubectl port-forward deployment/conditionorc-api --address 0.0.0.0 ${CONDITION_ORC_PORT}:${CONDITION_ORC_PORT} > /dev/null 2>&1 &
-	kubectl port-forward deployment/alloy --address 0.0.0.0 ${ALLOY_PORT}:${ALLOY_PORT} > /dev/null 2>&1 &
-	kubectl port-forward deployment/serverservice --address 0.0.0.0 ${HSS_PORT}:${HSS_PORT} > /dev/null 2>&1 &
-	kubectl port-forward deployment/crdb --address 0.0.0.0 ${CRDB_PORT}:${CRDB_PORT} > /dev/null 2>&1 &
-	kubectl port-forward deployment/fleetdb --address 0.0.0.0 ${HSS_PORT}:${HSS_PORT} > /dev/null 2>&1 &
-	kubectl port-forward deployment/fleetdb-crdb --address 0.0.0.0 ${CRDB_PORT}:${CRDB_PORT} > /dev/null 2>&1 &
-	kubectl port-forward service/chaos-dashboard --address 0.0.0.0 ${CHAOS_DASH_PORT}:${CHAOS_DASH_PORT} > /dev/null 2>&1 &
-	kubectl port-forward service/jaeger --address 0.0.0.0 ${JAEGER_DASH_PORT}:${JAEGER_DASH_PORT} > /dev/null 2>&1 &
-	kubectl port-forward deployment/minio --address 0.0.0.0 ${MINIO_PORT}:${MINIO_PORT} > /dev/null 2>&1
+	kubectl port-forward deployment/conditionorc-api --address 0.0.0.0 $(CONDITION_ORC_PORT):$(CONDITION_ORC_PORT) > /dev/null 2>&1 &
+	kubectl port-forward deployment/alloy --address 0.0.0.0 $(ALLOY_PORT):$(ALLOY_PORT) > /dev/null 2>&1 &
+	kubectl port-forward deployment/serverservice --address 0.0.0.0 $(HSS_PORT):$(HSS_PORT) > /dev/null 2>&1 &
+	kubectl port-forward deployment/crdb --address 0.0.0.0 $(CRDB_PORT):$(CRDB_PORT) > /dev/null 2>&1 &
+	kubectl port-forward deployment/fleetdb --address 0.0.0.0 $(HSS_PORT):$(HSS_PORT) > /dev/null 2>&1 &
+	kubectl port-forward deployment/fleetdb-crdb --address 0.0.0.0 $(CRDB_PORT):$(CRDB_PORT) > /dev/null 2>&1 &
+	kubectl port-forward service/chaos-dashboard --address 0.0.0.0 $(CHAOS_DASH_PORT):$(CHAOS_DASH_PORT) > /dev/null 2>&1 &
+	kubectl port-forward service/jaeger --address 0.0.0.0 $(JAEGER_DASH_PORT):$(JAEGER_DASH_PORT) > /dev/null 2>&1 &
+	kubectl port-forward deployment/minio --address 0.0.0.0 $(MINIO_PORT):$(MINIO_PORT) > /dev/null 2>&1
 
 port-all:
-	kubectl port-forward deployment/conditionorc-api ${CONDITION_ORC_PORT}:${CONDITION_ORC_PORT} > /dev/null 2>&1 &
-	kubectl port-forward deployment/alloy ${ALLOY_PORT}:${ALLOY_PORT} > /dev/null 2>&1 &
-	kubectl port-forward deployment/serverservice ${HSS_PORT}:${HSS_PORT} > /dev/null 2>&1 &
-	kubectl port-forward deployment/crdb ${CRDB_PORT}:${CRDB_PORT} > /dev/null 2>&1 &
-	kubectl port-forward deployment/fleetdb ${HSS_PORT}:${HSS_PORT} > /dev/null 2>&1 &
-	kubectl port-forward deployment/fleetdb-crdb ${CRDB_PORT}:${CRDB_PORT} > /dev/null 2>&1 &
-	kubectl port-forward service/chaos-dashboard ${CHAOS_DASH_PORT}:${CHAOS_DASH_PORT} > /dev/null 2>&1 &
-	kubectl port-forward service/jaeger ${JAEGER_DASH_PORT}:${JAEGER_DASH_PORT} > /dev/null 2>&1 &
-	kubectl port-forward deployment/minio ${MINIO_PORT}:${MINIO_PORT} > /dev/null 2>&1
+	kubectl port-forward deployment/conditionorc-api $(CONDITION_ORC_PORT):$(CONDITION_ORC_PORT) > /dev/null 2>&1 &
+	kubectl port-forward deployment/alloy $(ALLOY_PORT):$(ALLOY_PORT) > /dev/null 2>&1 &
+	kubectl port-forward deployment/serverservice $(HSS_PORT):$(HSS_PORT) > /dev/null 2>&1 &
+	kubectl port-forward deployment/crdb $(CRDB_PORT):$(CRDB_PORT) > /dev/null 2>&1 &
+	kubectl port-forward deployment/fleetdb $(HSS_PORT):$(HSS_PORT) > /dev/null 2>&1 &
+	kubectl port-forward deployment/fleetdb-crdb $(CRDB_PORT):$(CRDB_PORT) > /dev/null 2>&1 &
+	kubectl port-forward service/chaos-dashboard $(CHAOS_DASH_PORT):$(CHAOS_DASH_PORT) > /dev/null 2>&1 &
+	kubectl port-forward service/jaeger $(JAEGER_DASH_PORT):$(JAEGER_DASH_PORT) > /dev/null 2>&1 &
+	kubectl port-forward deployment/minio $(MINIO_PORT):$(MINIO_PORT) > /dev/null 2>&1
 
 ## kill all port fowarding processes that are running in the background
 kill-all-ports:
-	lsof -i:${CONDITION_ORC_PORT} -t | xargs kill
-	lsof -i:${ALLOY_PORT} -t | xargs kill
-	lsof -i:${HSS_PORT} -t | xargs kill
-	lsof -i:${CRDB_PORT} -t | xargs kill
-	lsof -i:${CHAOS_DASH_PORT} -t | xargs kill
-	lsof -i:${JAEGER_DASH_PORT} -t | xargs kill
-	lsof -i:${MINIO_PORT} -t | xargs kill
+	lsof -i:$(CONDITION_ORC_PORT) -t | xargs kill
+	lsof -i:$(ALLOY_PORT) -t | xargs kill
+	lsof -i:$(HSS_PORT) -t | xargs kill
+	lsof -i:$(CRDB_PORT) -t | xargs kill
+	lsof -i:$(CHAOS_DASH_PORT) -t | xargs kill
+	lsof -i:$(JAEGER_DASH_PORT) -t | xargs kill
+	lsof -i:$(MINIO_PORT) -t | xargs kill
 
 ## install extra services used to test firmware-syncer
 firmware-syncer-env:
@@ -147,7 +147,7 @@ TARGET_MAX_CHAR_NUM=32
 help:
 	@echo ''
 	@echo 'Usage:'
-	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo '  $(YELLOW)make$(RESET) $(GREEN)<target>$(RESET)'
 	@echo ''
 	@echo 'Targets:'
 	@awk '/^[a-zA-Z\-\\_0-9]+:/ { \
@@ -155,7 +155,7 @@ help:
 		if (helpMessage) { \
 			helpCommand = substr($$1, 0, index($$1, ":")-1); \
 			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
-			printf "  ${YELLOW}%-$(TARGET_MAX_CHAR_NUM)s${RESET} ${GREEN}%s${RESET}\n", helpCommand, helpMessage; \
+			printf "  $(YELLOW)%-$(TARGET_MAX_CHAR_NUM)s$(RESET) $(GREEN)%s$(RESET)\n", helpCommand, helpMessage; \
 		} \
 	} \
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -37,72 +37,72 @@ clean: kubectl-ctx-kind
 
 ## port forward condition orchestrator API  (runs in foreground)
 port-forward-conditionorc-api: kubectl-ctx-kind
-	kubectl port-forward deployment/conditionorc-api $(CONDITION_ORC_PORT):$(CONDITION_ORC_PORT)
+	kubectl port-forward deployment/conditionorc-api ${CONDITION_ORC_PORT}:${CONDITION_ORC_PORT}
 
 ## port forward condition Alloy pprof endpoint  (runs in foreground)
 port-forward-alloy-pprof: kubectl-ctx-kind
-	kubectl port-forward deployment/alloy $(ALLOY_PORT):$(ALLOY_PORT)
+	kubectl port-forward deployment/alloy ${ALLOY_PORT}:${ALLOY_PORT}
 
 ## port forward hollow server service port (runs in foreground)
 port-forward-hss: kubectl-ctx-kind
-	kubectl port-forward deployment/serverservice $(HSS_PORT):$(HSS_PORT)
+	kubectl port-forward deployment/serverservice ${HSS_PORT}:${HSS_PORT}
 
 ## port forward fleetdb port (runs in foreground)
 port-forward-fleetdb: kubectl-ctx-kind
-	kubectl port-forward deployment/fleetdb $(HSS_PORT):$(HSS_PORT)
+	kubectl port-forward deployment/fleetdb ${HSS_PORT}:${HSS_PORT}
 
 ## port forward crdb service port (runs in foreground)
 port-forward-crdb: kubectl-ctx-kind
-	kubectl port-forward deployment/crdb $(CRDB_PORT):$(CRDB_PORT)
+	kubectl port-forward deployment/crdb ${CRDB_PORT}:${CRDB_PORT}
 
 ## port forward fleetdb crdb service port (runs in foreground)
 port-forward-fleetdb-crdb: kubectl-ctx-kind
-	kubectl port-forward deployment/fleetdb-crdb $(CRDB_PORT):$(CRDB_PORT)
+	kubectl port-forward deployment/fleetdb-crdb ${CRDB_PORT}:${CRDB_PORT}
 
 ## port forward chaos-mesh dashboard (runs in foreground)
 port-forward-chaos-dash: kubectl-ctx-kind
-	kubectl port-forward service/chaos-dashboard $(CHAOS_DASH_PORT):$(CHAOS_DASH_PORT)
+	kubectl port-forward service/chaos-dashboard ${CHAOS_DASH_PORT}:${CHAOS_DASH_PORT}
 
 ## port forward jaeger frontend
 port-forward-jaeger-dash:
-	kubectl port-forward service/jaeger $(JAEGER_DASH_PORT):$(JAEGER_DASH_PORT)
+	kubectl port-forward service/jaeger ${JAEGER_DASH_PORT}:${JAEGER_DASH_PORT}
 
 ## port forward to the minio S3 port
 port-forward-minio:
-	kubectl port-forward deployment/minio $(MINIO_PORT):$(MINIO_PORT)
+	kubectl port-forward deployment/minio ${MINIO_PORT}:${MINIO_PORT}
 
 ## port forward all endpoints (runs in the background)
 port-all-with-lan:
-	kubectl port-forward deployment/conditionorc-api --address 0.0.0.0 $(CONDITION_ORC_PORT):$(CONDITION_ORC_PORT) > /dev/null 2>&1 &
-	kubectl port-forward deployment/alloy --address 0.0.0.0 $(ALLOY_PORT):$(ALLOY_PORT) > /dev/null 2>&1 &
-	kubectl port-forward deployment/serverservice --address 0.0.0.0 $(HSS_PORT):$(HSS_PORT) > /dev/null 2>&1 &
-	kubectl port-forward deployment/crdb --address 0.0.0.0 $(CRDB_PORT):$(CRDB_PORT) > /dev/null 2>&1 &
-	kubectl port-forward deployment/fleetdb --address 0.0.0.0 $(HSS_PORT):$(HSS_PORT) > /dev/null 2>&1 &
-	kubectl port-forward deployment/fleetdb-crdb --address 0.0.0.0 $(CRDB_PORT):$(CRDB_PORT) > /dev/null 2>&1 &
-	kubectl port-forward service/chaos-dashboard --address 0.0.0.0 $(CHAOS_DASH_PORT):$(CHAOS_DASH_PORT) > /dev/null 2>&1 &
-	kubectl port-forward service/jaeger --address 0.0.0.0 $(JAEGER_DASH_PORT):$(JAEGER_DASH_PORT) > /dev/null 2>&1 &
-	kubectl port-forward deployment/minio --address 0.0.0.0 $(MINIO_PORT):$(MINIO_PORT) > /dev/null 2>&1
+	kubectl port-forward deployment/conditionorc-api --address 0.0.0.0 ${CONDITION_ORC_PORT}:${CONDITION_ORC_PORT} > /dev/null 2>&1 &
+	kubectl port-forward deployment/alloy --address 0.0.0.0 ${ALLOY_PORT}:${ALLOY_PORT} > /dev/null 2>&1 &
+	kubectl port-forward deployment/serverservice --address 0.0.0.0 ${HSS_PORT}:${HSS_PORT} > /dev/null 2>&1 &
+	kubectl port-forward deployment/crdb --address 0.0.0.0 ${CRDB_PORT}:${CRDB_PORT} > /dev/null 2>&1 &
+	kubectl port-forward deployment/fleetdb --address 0.0.0.0 ${HSS_PORT}:${HSS_PORT} > /dev/null 2>&1 &
+	kubectl port-forward deployment/fleetdb-crdb --address 0.0.0.0 ${CRDB_PORT}:${CRDB_PORT} > /dev/null 2>&1 &
+	kubectl port-forward service/chaos-dashboard --address 0.0.0.0 ${CHAOS_DASH_PORT}:${CHAOS_DASH_PORT} > /dev/null 2>&1 &
+	kubectl port-forward service/jaeger --address 0.0.0.0 ${JAEGER_DASH_PORT}:${JAEGER_DASH_PORT} > /dev/null 2>&1 &
+	kubectl port-forward deployment/minio --address 0.0.0.0 ${MINIO_PORT}:${MINIO_PORT} > /dev/null 2>&1
 
 port-all:
-	kubectl port-forward deployment/conditionorc-api $(CONDITION_ORC_PORT):$(CONDITION_ORC_PORT) > /dev/null 2>&1 &
-	kubectl port-forward deployment/alloy $(ALLOY_PORT):$(ALLOY_PORT) > /dev/null 2>&1 &
-	kubectl port-forward deployment/serverservice $(HSS_PORT):$(HSS_PORT) > /dev/null 2>&1 &
-	kubectl port-forward deployment/crdb $(CRDB_PORT):$(CRDB_PORT) > /dev/null 2>&1 &
-	kubectl port-forward deployment/fleetdb $(HSS_PORT):$(HSS_PORT) > /dev/null 2>&1 &
-	kubectl port-forward deployment/fleetdb-crdb $(CRDB_PORT):$(CRDB_PORT) > /dev/null 2>&1 &
-	kubectl port-forward service/chaos-dashboard $(CHAOS_DASH_PORT):$(CHAOS_DASH_PORT) > /dev/null 2>&1 &
-	kubectl port-forward service/jaeger $(JAEGER_DASH_PORT):$(JAEGER_DASH_PORT) > /dev/null 2>&1 &
-	kubectl port-forward deployment/minio $(MINIO_PORT):$(MINIO_PORT) > /dev/null 2>&1
+	kubectl port-forward deployment/conditionorc-api ${CONDITION_ORC_PORT}:${CONDITION_ORC_PORT} > /dev/null 2>&1 &
+	kubectl port-forward deployment/alloy ${ALLOY_PORT}:${ALLOY_PORT} > /dev/null 2>&1 &
+	kubectl port-forward deployment/serverservice ${HSS_PORT}:${HSS_PORT} > /dev/null 2>&1 &
+	kubectl port-forward deployment/crdb ${CRDB_PORT}:${CRDB_PORT} > /dev/null 2>&1 &
+	kubectl port-forward deployment/fleetdb ${HSS_PORT}:${HSS_PORT} > /dev/null 2>&1 &
+	kubectl port-forward deployment/fleetdb-crdb ${CRDB_PORT}:${CRDB_PORT} > /dev/null 2>&1 &
+	kubectl port-forward service/chaos-dashboard ${CHAOS_DASH_PORT}:${CHAOS_DASH_PORT} > /dev/null 2>&1 &
+	kubectl port-forward service/jaeger ${JAEGER_DASH_PORT}:${JAEGER_DASH_PORT} > /dev/null 2>&1 &
+	kubectl port-forward deployment/minio ${MINIO_PORT}:${MINIO_PORT} > /dev/null 2>&1
 
 ## kill all port fowarding processes that are running in the background
 kill-all-ports:
-	lsof -i:$(CONDITION_ORC_PORT) -t | xargs kill
-	lsof -i:$(ALLOY_PORT) -t | xargs kill
-	lsof -i:$(HSS_PORT) -t | xargs kill
-	lsof -i:$(CRDB_PORT) -t | xargs kill
-	lsof -i:$(CHAOS_DASH_PORT) -t | xargs kill
-	lsof -i:$(JAEGER_DASH_PORT) -t | xargs kill
-	lsof -i:$(MINIO_PORT) -t | xargs kill
+	lsof -i:${CONDITION_ORC_PORT} -t | xargs kill
+	lsof -i:${ALLOY_PORT} -t | xargs kill
+	lsof -i:${HSS_PORT} -t | xargs kill
+	lsof -i:${CRDB_PORT} -t | xargs kill
+	lsof -i:${CHAOS_DASH_PORT} -t | xargs kill
+	lsof -i:${JAEGER_DASH_PORT} -t | xargs kill
+	lsof -i:${MINIO_PORT} -t | xargs kill
 
 ## install extra services used to test firmware-syncer
 firmware-syncer-env:
@@ -147,7 +147,7 @@ TARGET_MAX_CHAR_NUM=32
 help:
 	@echo ''
 	@echo 'Usage:'
-	@echo '  $(YELLOW)make$(RESET) $(GREEN)<target>$(RESET)'
+	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
 	@echo ''
 	@echo 'Targets:'
 	@awk '/^[a-zA-Z\-\\_0-9]+:/ { \
@@ -155,7 +155,7 @@ help:
 		if (helpMessage) { \
 			helpCommand = substr($$1, 0, index($$1, ":")-1); \
 			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
-			printf "  $(YELLOW)%-$(TARGET_MAX_CHAR_NUM)s$(RESET) $(GREEN)%s$(RESET)\n", helpCommand, helpMessage; \
+			printf "  ${YELLOW}%-${TARGET_MAX_CHAR_NUM}s${RESET} ${GREEN}%s${RESET}\n", helpCommand, helpMessage; \
 		} \
 	} \
-	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+	{ lastLine = $$0 }' ${MAKEFILE_LIST}

--- a/scripts/nats-bootstrap/boostrap.sh
+++ b/scripts/nats-bootstrap/boostrap.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
-CPWD=$(PWD)
+CPWD=$(pwd)
 [[ "$(basename $CPWD)" != "sandbox" ]] && echo "This script should be executed from the repo top level directory" && exit 1
 
 echo "Note: this will purge all current NATS related k8s objects and services"
@@ -19,7 +19,23 @@ init_natsaccounts
 update_values_nats_yaml
 init_natsserver
 push_natsaccounts
-push_controller_secrets
+
+if [ "$(uname)" == "Darwin" ]; then
+	push_controller_secrets_macos
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+	push_controller_secrets_linux
+else
+	echo "Unknown OS detected! push_controller_secrets not called!"
+fi
+
 reload_controller_deployments
-push_serverservice_secrets
+
+if [ "$(uname)" == "Darwin" ]; then
+	push_serverservice_secrets_macos
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+	push_serverservice_secrets_linux
+else
+	echo "Unknown OS detected! push_serverservice_secrets not called!"
+fi
+
 backup_accounts

--- a/scripts/nats-bootstrap/boostrap.sh
+++ b/scripts/nats-bootstrap/boostrap.sh
@@ -19,23 +19,7 @@ init_natsaccounts
 update_values_nats_yaml
 init_natsserver
 push_natsaccounts
-
-if [ "$(uname)" == "Darwin" ]; then
-	push_controller_secrets_macos
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-	push_controller_secrets_linux
-else
-	echo "Unknown OS detected! push_controller_secrets not called!"
-fi
-
+push_controller_secrets
 reload_controller_deployments
-
-if [ "$(uname)" == "Darwin" ]; then
-	push_serverservice_secrets_macos
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-	push_serverservice_secrets_linux
-else
-	echo "Unknown OS detected! push_serverservice_secrets not called!"
-fi
-
+push_serverservice_secrets
 backup_accounts

--- a/scripts/nats-bootstrap/functions.sh
+++ b/scripts/nats-bootstrap/functions.sh
@@ -198,27 +198,27 @@ function update_values_nats_yaml() {
 	mv $f values-nats.yaml
 }
 
-function push_controller_secrets_macos() {
+function encode_creds_base64() {
+	if [ "$(uname)" == "Darwin" ]; then
+		cred_temp=$(kuexec "${1}" | gbase64 -w 0)
+	elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+		cred_temp=$(kuexec "${1}" | base64 | tr -d "\n")
+	else
+		cred_temp="Unknown OS detected! Couldnt encode credentials!"
+	fi
+
+	echo "${cred_temp}"
+}
+
+function push_controller_secrets() {
 	for controller in conditionorc alloy flasher; do
-		sekrit=$(kuexec "cat /root/nsc/nkeys/creds/KO/controllers/${controller}.creds" | gbase64 -w 0)
+		sekrit=$(encode_creds_base64 "cat /root/nsc/nkeys/creds/KO/controllers/${controller}.creds")
 		push_secret "${sekrit}" ${controller}
 	done
 }
 
-function push_controller_secrets_linux() {
-		for controller in conditionorc alloy flasher; do
-			sekrit=$(kuexec "cat /root/nsc/nkeys/creds/KO/controllers/${controller}.creds" | base64 | tr -d "\n")
-			push_secret "${sekrit}" ${controller}
-		done
-}
-
-function push_serverservice_secrets_macos() {
-	sekrit=$(kuexec "cat /root/nsc/nkeys/creds/KO/serverservice/serverservice.creds" | gbase64 -w 0)
-	push_secret "${sekrit}" serverservice
-}
-
-function push_serverservice_secrets_linux() {
-	sekrit=$(kuexec "cat /root/nsc/nkeys/creds/KO/serverservice/serverservice.creds" | base64 | tr -d "\n")
+function push_serverservice_secrets() {
+	sekrit=$(encode_creds_base64 "cat /root/nsc/nkeys/creds/KO/serverservice/serverservice.creds")
 	push_secret "${sekrit}" serverservice
 }
 

--- a/scripts/nats-bootstrap/functions.sh
+++ b/scripts/nats-bootstrap/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # - `Accounts` group users and Jetstream support is enabled/disabled at the account level NOTE: pub/sub permissions set at the Account level are not inherited by users of that account.
 # - `Signing keys` are associated with accounts and can be 'templated' with pub/sub permissions and have a `role` name set.
@@ -93,7 +93,7 @@ nsc edit signing-key -a controllers --sk ${SK_A} --role controllers
 
 # https://docs.nats.io/reference/reference-protocols/nats_api_reference
 nsc edit signing-key -a controllers --sk ${SK_A} \
-    --allow-pubsub '$KV.>' \
+	--allow-pubsub '$KV.>' \
 	--allow-pubsub '$JS.API.DIRECT.GET.>' \
 	--allow-pubsub '$JS.API.INFO' \
 	--allow-pubsub '$JS.API.STREAM.INFO.controllers' \
@@ -120,23 +120,23 @@ nsc edit signing-key -a controllers --sk ${SK_A} \
 	--allow-pubsub '$JS.API.CONSUMER.CREATE.KV_active-conditions' \
 	--allow-pubsub '$JS.API.CONSUMER.CREATE.KV_active-conditions.>' \
 	--allow-pubsub '$JS.API.CONSUMER.DELETE.KV_active-conditions.>' \
-    --allow-pubsub '$JS.API.STREAM.INFO.KV_active-conditions' \
-    --allow-pubsub '$JS.API.STREAM.INFO.KV_active-conditions.>' \
-    --allow-pubsub '$JS.API.STREAM.CREATE.KV_active-conditions' \
-    --allow-pubsub '$JS.API.STREAM.CREATE.KV_active-conditions.>' \
-    --allow-pubsub '$JS.API.STREAM.INFO.KV_active-controllers' \
-    --allow-pubsub '$JS.API.STREAM.INFO.KV_active-controllers.>' \
-    --allow-pubsub '$JS.API.STREAM.CREATE.KV_active-controllers' \
-    --allow-pubsub '$JS.API.STREAM.CREATE.KV_active-controllers.>' \
-    --allow-pubsub '$JS.API.STREAM.INFO.KV_firmwareInstall' \
-    --allow-pubsub '$JS.API.STREAM.INFO.KV_firmwareInstall.>' \
-    --allow-pubsub '$JS.API.STREAM.CREATE.KV_firmwareInstall' \
-    --allow-pubsub '$JS.API.STREAM.CREATE.KV_firmwareInstall.>' \
-    --allow-pubsub '$JS.API.STREAM.INFO.KV_inventory' \
-    --allow-pubsub '$JS.API.STREAM.INFO.KV_inventory.>' \
-    --allow-pubsub '$JS.API.STREAM.CREATE.KV_inventory' \
-    --allow-pubsub '$JS.API.STREAM.CREATE.KV_inventory.>' \
-    --allow-pubsub '$JS.ACK.controllers.>' \
+	--allow-pubsub '$JS.API.STREAM.INFO.KV_active-conditions' \
+	--allow-pubsub '$JS.API.STREAM.INFO.KV_active-conditions.>' \
+	--allow-pubsub '$JS.API.STREAM.CREATE.KV_active-conditions' \
+	--allow-pubsub '$JS.API.STREAM.CREATE.KV_active-conditions.>' \
+	--allow-pubsub '$JS.API.STREAM.INFO.KV_active-controllers' \
+	--allow-pubsub '$JS.API.STREAM.INFO.KV_active-controllers.>' \
+	--allow-pubsub '$JS.API.STREAM.CREATE.KV_active-controllers' \
+	--allow-pubsub '$JS.API.STREAM.CREATE.KV_active-controllers.>' \
+	--allow-pubsub '$JS.API.STREAM.INFO.KV_firmwareInstall' \
+	--allow-pubsub '$JS.API.STREAM.INFO.KV_firmwareInstall.>' \
+	--allow-pubsub '$JS.API.STREAM.CREATE.KV_firmwareInstall' \
+	--allow-pubsub '$JS.API.STREAM.CREATE.KV_firmwareInstall.>' \
+	--allow-pubsub '$JS.API.STREAM.INFO.KV_inventory' \
+	--allow-pubsub '$JS.API.STREAM.INFO.KV_inventory.>' \
+	--allow-pubsub '$JS.API.STREAM.CREATE.KV_inventory' \
+	--allow-pubsub '$JS.API.STREAM.CREATE.KV_inventory.>' \
+	--allow-pubsub '$JS.ACK.controllers.>' \
 	--allow-sub 'com.hollow.sh.serverservice.events.>' \
 	--allow-pubsub 'com.hollow.sh.controllers.>' \
 	--allow-sub 'com.hollow.sh.controllers.commands.>' \
@@ -186,7 +186,7 @@ function update_values_nats_yaml() {
 	OPKEY=$(kuexec "nsc generate config --sys-account SYS --nats-resolver | awk  '/operator: /{print \$2}' | tr -d '\\r' ")
 	SYSKEY=$(kuexec "nsc generate config --sys-account SYS --nats-resolver | awk '/system_account: /{print \$2}' | tr -d '\\r' ")
 	SYSPRELOADKEY=$(kuexec "nsc generate config --sys-account SYS  --nats-resolver |  \
-    grep resolver_preload -A1 | sed -e 's/,//g' -e 's/{//g'  | awk -F': ' '/: /{print \$2}' | tr -d '\r' ")
+	grep resolver_preload -A1 | sed -e 's/,//g' -e 's/{//g'  | awk -F': ' '/: /{print \$2}' | tr -d '\r' ")
 
 	OPKEY=$(echo $OPKEY | tr -d '\r')
 	SYSKEY=$(echo $SYSKEY | tr -d '\r')
@@ -198,33 +198,44 @@ function update_values_nats_yaml() {
 	mv $f values-nats.yaml
 }
 
-function push_controller_secrets() {
+function push_controller_secrets_macos() {
 	for controller in conditionorc alloy flasher; do
 		sekrit=$(kuexec "cat /root/nsc/nkeys/creds/KO/controllers/${controller}.creds" | gbase64 -w 0)
-    push_secret "${sekrit}" ${controller}
+		push_secret "${sekrit}" ${controller}
 	done
 }
 
-function push_serverservice_secrets() {
+function push_controller_secrets_linux() {
+		for controller in conditionorc alloy flasher; do
+			sekrit=$(kuexec "cat /root/nsc/nkeys/creds/KO/controllers/${controller}.creds" | base64 | tr -d "\n")
+			push_secret "${sekrit}" ${controller}
+		done
+}
+
+function push_serverservice_secrets_macos() {
 	sekrit=$(kuexec "cat /root/nsc/nkeys/creds/KO/serverservice/serverservice.creds" | gbase64 -w 0)
 	push_secret "${sekrit}" serverservice
 }
 
+function push_serverservice_secrets_linux() {
+	sekrit=$(kuexec "cat /root/nsc/nkeys/creds/KO/serverservice/serverservice.creds" | base64 | tr -d "\n")
+	push_secret "${sekrit}" serverservice
+}
+
 function push_secret() {
-  sekrit=$1
-  name=$2
-  file=/tmp/kind_${name}_secret.yaml
+	sekrit=$1
+	name=$2
 
-	echo "apiVersion: v1
-metadata:
-  name: ${name}-secrets
-  namespace: default
-data:
-  ${name}-nats-creds: ${sekrit}
-kind: Secret
-type: Opaque" > "${file}"
-
-	kubectl apply -f "${file}"
+	cat <<-EOF | kubectl apply -f -
+		apiVersion: v1
+		metadata:
+		  name: ${name}-secrets
+		  namespace: default
+		data:
+		  ${name}-nats-creds: ${sekrit}
+		kind: Secret
+		type: Opaque
+	EOF
 }
 
 function reload_controller_deployments() {

--- a/scripts/nats-bootstrap/functions.sh
+++ b/scripts/nats-bootstrap/functions.sh
@@ -4,16 +4,7 @@
 # - `Signing keys` are associated with accounts and can be 'templated' with pub/sub permissions and have a `role` name set.
 # - `Users` are applications connecting to NATS to pub/sub, users can be assigned a `role`.
 
-# While "base64" exists on MacOS, it seems to be an older verison without the '-w' option.
-# So we will use os_base64 to make it work cleanly on linux and macos
-if [ "$(uname)" == "Darwin" ]; then
-	os_base64=(gbase64)
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-	os_base64=(base64)
-else
-	echo "Unknown OS detected! Couldnt encode credentials!"
-	exit 1
-fi
+source scripts/nats-bootstrap/validation.sh
 
 function clean_natsserver() {
 	set +e

--- a/scripts/nats-bootstrap/validation.sh
+++ b/scripts/nats-bootstrap/validation.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+OS=$(uname -s)
+
+function validate_command() {
+	if ! [ -x "$(command -v $1)" ]; then
+		echo "Error: On $OS. Command $1 isnt found!"
+		exit 1
+	fi
+}
+
+# While "base64" exists on MacOS, it is the BSD verison without the '-w' option. We want the GNU version.
+# So we will use os_base64 to make it work cleanly on linux and macos
+if [[ $OS == *"Darwin"* ]]; then
+	validate_command gbase64
+	os_base64=(gbase64)
+elif [[ $OS == *"Linux"* ]]; then
+	validate_command base64
+	os_base64=(base64)
+else
+	echo "Error: Unknown/Unsupported OS detected!"
+	exit 1
+fi
+
+validate_command helm
+validate_command kubectl
+validate_command make

--- a/templates/fleet-scheduler-configmap.yaml
+++ b/templates/fleet-scheduler-configmap.yaml
@@ -8,12 +8,12 @@ metadata:
 data:
   config.yaml: |
     log_level: {{ .Values.fleetscheduler.env.log_level }}
-    store_kind: fleetscheduler
-    facility_code: {{ .Values.fleetscheduler.env.facility }}
+    store_kind: fleet-scheduler
+    facility_code: {{ .Values.clusterInfo.facility }}
     fleetdb_api:
-      endpoint: {{ .Values.fleetscheduler.env.serverservice.endpoint }}
       disable_oauth: {{ .Values.fleetscheduler.env.serverservice.disable_oauth }}
+      endpoint: {{ .Values.fleetscheduler.env.serverservice.endpoint }}
     conditionorc_api:
-      endpoint: {{ .Values.fleetscheduler.env.conditionorc.endpoint }}"
       disable_oauth: {{ .Values.fleetscheduler.env.conditionorc.disable_oauth }}
+      endpoint: {{ .Values.fleetscheduler.env.conditionorc.endpoint }}
 {{ end }}

--- a/templates/fleet-scheduler-cronjob.yaml
+++ b/templates/fleet-scheduler-cronjob.yaml
@@ -7,15 +7,15 @@ metadata:
   labels:
     k8s-service: fleet-scheduler
 spec:
-  {{- with $job.ttl }}
-  ttlSecondsAfterFinished: {{ . }}
-  {{- end}}
   {{- with $job.deadline }}
-  startingDeadline: {{ . }}
+  startingDeadlineSeconds: {{ . }}
   {{- end}}
   schedule: {{ $job.schedule | quote }}
   jobTemplate:
     spec:
+      {{- with $job.ttl }}
+      ttlSecondsAfterFinished: {{ . }}
+      {{- end}}
       template:
         spec:
           restartPolicy: {{ $job.restartPolicy }}
@@ -25,7 +25,7 @@ spec:
                 name: fleet-scheduler-config
           containers:
           - name: {{ $job.name }}
-            image: {{ $job.image }}:{{ $job.tag }}
+            image: {{ $.Values.repository }}:{{ $job.tag }}
             imagePullPolicy: {{ $job.imagePullPolicy }}
             {{- with $job.command }}
             command:

--- a/values.yaml
+++ b/values.yaml
@@ -162,11 +162,10 @@ fleetscheduler:
       disable_oauth: true
   jobs: # technically, this is optional
     - name: inventory # This job will collect all servers and create conditions on them within the facility fleetscheduler.facility defined in this yaml
-      tt: 86400 # Remove job after 1 day. (optional)
-      deadline: 3600 # The job has 1 hour to run the task, if it cant after 1 hour, it wont run. (optional)
+      ttlSecondsAfterFinished: 86400 # Remove job after 1 day. (optional)
+      startingDeadlineSeconds: 3600 # The job has 1 hour to run the task, if it cant after 1 hour, it wont run. (optional)
       restartPolicy: OnFailure
       imagePullPolicy: Always
-      image: localhost:5001/fleet-scheduler
       tag: latest
       schedule: "0 9 * * *" # Run every day at 9am
       command:


### PR DESCRIPTION
- Fleet scheduler yaml file updates to support changes made for the helm chart
- Linux support. Making the scripts more uniform across MacOS/Linux. Will require small updates to each project in the sandbox for it to work (building with CGO_ENABLED=0)
- Cleaning up the makefile. We use {} and () interchangeably. Which is supported by the [documentation](https://www.gnu.org/software/make/manual/html_node/Reference.html#Reference). This however is just a bit weird, and we should only do it one way or another.
- Cleaning up the "push_secrets" bash function. It was kinda messy, this new method of using [hereDocs](https://tldp.org/LDP/abs/html/here-docs.html) simplifies it.