### PR TITLE
Fixes for bad awk syntax and error when .local-values.yaml doesnt exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,18 +137,19 @@ kubectl-ctx-kind:
 ## Note: Use `make fleet-scheduler-upstream` to revert this process
 %-local:
 	$(eval DIR ?= ../)
-	./scripts/makefile/set-service-to-local.sh $(subst -local,,$@) ${DIR}
+	@./scripts/makefile/set-service-to-local.sh $(subst -local,,$@) ${DIR}
 
 ## Change service to upstream service instead of local.
 ## Example: `make fleet-scheduler-upstream` will tell sandbox to use the upstream (https://metal-toolbox.github.io/fleet-scheduler) fleet-scheduler.
 %-upstream:
-	yq -i "del(.localrepos.[] | select(.name == \"$(subst -upstream,,$@)\"))" .local-values.yaml
+	@touch .local-values.yaml
+	@yq -i "del(.localrepos.[] | select(.name == \"$(subst -upstream,,$@)\"))" .local-values.yaml
 
 ## Get some meta info about a service.
 ## Example: `make fleet-scheduler-info`
 %-info:
-	./scripts/makefile/get-service-info.sh $(subst -info,,$@)
+	@./scripts/makefile/get-service-info.sh $(subst -info,,$@)
 
 ## Show help
 help:
-	./scripts/makefile/help.awk ${MAKEFILE_LIST}
+	@./scripts/makefile/help.awk ${MAKEFILE_LIST}

--- a/scripts/makefile/functions.sh
+++ b/scripts/makefile/functions.sh
@@ -2,6 +2,9 @@
 
 # This script will do some checks about availability of commands and input variables.
 
+TEMPFILE=.local-values.yaml
+touch $TEMPFILE
+
 # Check for yq
 if ! command -v yq &> /dev/null; then
 	echo "yq tool could not be found, please install yq (https://github.com/mikefarah/yq/)"

--- a/scripts/makefile/generate-chart.sh
+++ b/scripts/makefile/generate-chart.sh
@@ -2,11 +2,11 @@
 
 # Generate files for local service overriding
 
-./scripts/makefile/functions.sh
+. ./scripts/makefile/functions.sh
 
 cp Chart.yaml.tmpl Chart.yaml
 
-LENGTH=$(yq ".localrepos | length" .local-values.yaml)
+LENGTH=$(yq ".localrepos | length" $TEMPFILE)
 
 for ((I=0;I<LENGTH;I++)); do
 	SERVICE=$(yq ".localrepos.[$I].name" .local-values.yaml)

--- a/scripts/makefile/get-service-info.sh
+++ b/scripts/makefile/get-service-info.sh
@@ -2,9 +2,7 @@
 
 # This script will get some info about a service.
 
-TEMPFILE=.local-values.yaml
-
-./scripts/makefile/functions.sh $1
+. ./scripts/makefile/functions.sh $1
 
 # Check to make sure a service was specified
 if [[ -z "$1" ]]; then
@@ -13,7 +11,8 @@ if [[ -z "$1" ]]; then
 fi
 SERVICE=$1
 
-touch $TEMPFILE
+# make sure Chart.yaml is updated
+./scripts/makefile/generate-chart.sh
 
 DOCKER_URL=$(yq ".$SERVICE.image.repository.url" $TEMPFILE)
 if [[ "$DOCKER_URL" == "null" ]]; then

--- a/scripts/makefile/help.awk
+++ b/scripts/makefile/help.awk
@@ -1,4 +1,4 @@
-#!/bin/awk -f
+#!/usr/bin/env -S awk -f
 
 BEGIN {
 	PADDING = 32
@@ -14,8 +14,8 @@ BEGIN {
 	printf "Targets:\n"
 }
 
-/^[a-zA-Z\-\\_0-9\%]+:/ {
-	helpCommand = substr($$1, 0, index($$1, ":")-1)
+/^[a-zA-Z\-\\_0-9%]+:/ {
+	helpCommand = substr($1, 0, index($1, ":")-1)
 	printf "  %s%-*s %s%s%s\n", YELLOW, PADDING, helpCommand, GREEN, messageArray[0], RESET
 	for (i = 1; i < messageArrayLength; i++) {
 		printf "   %-*s-%s%s%s%s\n", PADDING, "", LIGHTGREEN, ITALLIC, messageArray[i], RESET
@@ -24,9 +24,9 @@ BEGIN {
 }
 
 {
-	helpMessage = match($$0, /^## (.*)/)
+	helpMessage = match($0, /^## (.*)/)
 	if (helpMessage) {
-		helpMessage = substr($$0, RSTART + 3, RLENGTH)
+		helpMessage = substr($0, RSTART + 3, RLENGTH)
 		messageArray[messageArrayLength++] = helpMessage
 	}
 }

--- a/scripts/makefile/set-service-to-local.sh
+++ b/scripts/makefile/set-service-to-local.sh
@@ -2,9 +2,7 @@
 
 # This script will swap the sandbox to a local instance of a service
 
-TEMPFILE=.local-values.yaml
-
-./scripts/makefile/functions.sh $1
+. ./scripts/makefile/functions.sh $1
 
 # Check to make sure a service was specified
 if [[ -z "$1" ]]; then
@@ -29,7 +27,5 @@ if [ ! -f "$CHARTYAML" ]; then
 	echo "Service path not found: $CHARTYAML"
 	exit 1
 fi
-
-touch $TEMPFILE
 
 yq -i ".localrepos *=d [{\"name\":\"$SERVICE\", \"relpath\":\"$DIR\"}]" $TEMPFILE


### PR DESCRIPTION
The help.awk script breaks on FreeBSD Awk, so changes to help.awk fix that.

There was a instance or two where if .local-values.yaml didnt exist, the script would fail. I added additional checks to make sure the file exists.

Also added some '@'s in the makefile to make running commands look a bit cleaner.