### PR TITLE
Small changes to allow sandbox to support newer versions of conditionorc, and flipflop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,10 @@ kubectl-ctx-kind:
 %-info:
 	@./scripts/makefile/get-service-info.sh $(subst -info,,$@)
 
+## Tail logs of a service
+%-log:
+	kubectl logs -f $$(kubectl get pods | grep -Po '$(subst -log,,$@)-([0-9]|[a-z])*-([0-9]|[a-z])* ')
+
 ## Show help
 help:
 	@./scripts/makefile/help.awk ${MAKEFILE_LIST}

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,10 @@ kubectl-ctx-kind:
 %-log:
 	kubectl logs -f $$(kubectl get pods | grep -Po '$(subst -log,,$@)-([0-9]|[a-z])*-([0-9]|[a-z])* ')
 
+## Enter a pod with bash
+%-bash:
+	kubectl exec -ti $$(kubectl get pods | grep -Po '$(subst -bash,,$@)-([0-9]|[a-z])*-([0-9]|[a-z])* ') -- /bin/sh
+
 ## Show help
 help:
 	@./scripts/makefile/help.awk ${MAKEFILE_LIST}

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ mctl create  firmware --from-file ./scripts/mctl/firmwares.json
 List the firmware using `mctl list firmware` and create a set that can be applied to a server.
 
 ```sh
-mctl create firmware-set --firmware-uuids 5e574c96-6ba4-4078-9650-c52a64cc8cba,a7e86975-11a4-433d-9170-af53fcfc79bd \
+mctl create firmware-set --firmware-ids 5e574c96-6ba4-4078-9650-c52a64cc8cba,a7e86975-11a4-433d-9170-af53fcfc79bd \
                          --labels vendor=dell,model=r6515,latest=true \
                          --name r6515
 ```

--- a/scripts/mctl/firmwares.json
+++ b/scripts/mctl/firmwares.json
@@ -10,7 +10,9 @@
     "component": "bios",
     "checksum": "md5sum:c6da4c4638c1d94c27dbea1206434cef",
     "upstream_url": "https://www.supermicro.com/about/policies/disclaimer.cfm?SoftwareItemID=12864",
-    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/supermicro/X11SSE0.B25"
+    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/supermicro/X11SSE0.B25",
+    "install_inband": false,
+    "oem": false
   },
   {
     "uuid": "9d6c75dc-9f06-41cf-aedc-93973ed5f372",
@@ -24,7 +26,9 @@
     "component": "storagecontroller",
     "checksum": "md5sum:7aaafabbea1be3c109a003ba667f0056",
     "upstream_url": "https://dl.dell.com/FOLDER05653958M/2/SAS-Non-RAID_Firmware_YXWY1_WN32_16.17.00.05_A07_01.EXE",
-    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/dell/SAS-Non-RAID_Firmware_YXWY1_WN32_16.17.00.05_A07_01.EXE"
+    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/dell/SAS-Non-RAID_Firmware_YXWY1_WN32_16.17.00.05_A07_01.EXE",
+    "install_inband": false,
+    "oem": false
   },
   {
     "uuid": "9a01e25a-2ab3-41b9-af42-2c30dc4dd51c",
@@ -38,7 +42,9 @@
     "component": "storagecontroller",
     "checksum": "md5sum:b9f12aeec12b00ad5aea6e3b0fef7feb",
     "upstream_url": "https://dl.dell.com/FOLDER08925211M/1/SAS-Non-RAID_Firmware_2MHMF_WN64_22.15.05.00_A04.EXE",
-    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/dell/SAS-Non-RAID_Firmware_2MHMF_WN64_22.15.05.00_A04.EXE"
+    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/dell/SAS-Non-RAID_Firmware_2MHMF_WN64_22.15.05.00_A04.EXE",
+    "install_inband": false,
+    "oem": false
   },
   {
     "uuid": "effec15b-b55e-4aaa-bcd4-c53e5a3b06ba",
@@ -51,7 +57,9 @@
     "component": "bios",
     "checksum": "md5sum:60fc390b456dde9b84be3e78ca6d3886",
     "upstream_url": "https://dl.dell.com/FOLDER08105057M/1/BIOS_C4FT0_WN64_2.6.6.EXE",
-    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/dell/BIOS_C4FT0_WN64_2.6.6.EXE"
+    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/dell/BIOS_C4FT0_WN64_2.6.6.EXE",
+    "install_inband": false,
+    "oem": false
   },
   {
     "uuid": "ed4513bd-671a-48a5-945d-90a90578634d",
@@ -64,7 +72,9 @@
     "component": "bios",
     "checksum": "md5sum:00559360bb7d1e267689ee86593a3b54",
     "upstream_url": "https://dl.dell.com/FOLDER09230230M/1/BIOS_517K6_WN64_1.19.0.EXE",
-    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/dell/BIOS_517K6_WN64_1.19.0.EXE"
+    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/dell/BIOS_517K6_WN64_1.19.0.EXE",
+    "install_inband": false,
+    "oem": false
   },
   {
     "uuid": "52f1581e-db75-44e2-9566-69982545c1b7",
@@ -78,7 +88,9 @@
     "component": "storagecontroller",
     "checksum": "md5sum:f9a156b4b077c826aa65eb8f1384efc3",
     "upstream_url": "https://dl.dell.com/FOLDER06189651M/3/SAS-RAID_Firmware_3P39V_WN64_2.5.13.3024_A07_02.EXE",
-    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/dell/SAS-RAID_Firmware_3P39V_WN64_2.5.13.3024_A07_02.EXE"
+    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/dell/SAS-RAID_Firmware_3P39V_WN64_2.5.13.3024_A07_02.EXE",
+    "install_inband": false,
+    "oem": false
   },
   {
     "uuid": "e5ffd884-5962-47da-b3e6-938ac6da6377",
@@ -91,6 +103,8 @@
     "component": "bios",
     "checksum": "md5sum:e0bcc56ae8939b1a37ed4f18048643cc",
     "upstream_url": "https://dl.dell.com/FOLDER08691055M/3/BIOS_NDFHH_WN64_2.15.1.EXE",
-    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/dell/BIOS_NDFHH_WN64_2.15.1.EXE"
+    "repository_url": "https://ARTIFACTS_ENDPOINT/firmware/files/dell/BIOS_NDFHH_WN64_2.15.1.EXE",
+    "install_inband": false,
+    "oem": false
   }
 ]

--- a/scripts/nats-bootstrap/functions.sh
+++ b/scripts/nats-bootstrap/functions.sh
@@ -83,6 +83,9 @@ nsc edit signing-key -a controllers --sk ${SK_A} \
 	--allow-pubsub '$JS.API.CONSUMER.CREATE.controllers.>' \
 	--allow-pubsub '$JS.API.CONSUMER.MSG.NEXT.controllers.>' \
 	--allow-pubsub '$JS.API.CONSUMER.DELETE.controllers.>' \
+	--allow-pubsub '$JS.API.CONSUMER.CREATE.KV_tasks' \
+	--allow-pubsub '$JS.API.CONSUMER.CREATE.KV_tasks.>' \
+	--allow-pubsub '$JS.API.CONSUMER.DELETE.KV_tasks.>' \
 	--allow-pubsub '$JS.API.CONSUMER.CREATE.KV_firmwareInstall' \
 	--allow-pubsub '$JS.API.CONSUMER.CREATE.KV_firmwareInstall.>' \
 	--allow-pubsub '$JS.API.CONSUMER.DELETE.KV_firmwareInstall.>' \
@@ -109,6 +112,10 @@ nsc edit signing-key -a controllers --sk ${SK_A} \
 	--allow-pubsub '$JS.API.STREAM.INFO.KV_active-controllers.>' \
 	--allow-pubsub '$JS.API.STREAM.CREATE.KV_active-controllers' \
 	--allow-pubsub '$JS.API.STREAM.CREATE.KV_active-controllers.>' \
+	--allow-pubsub '$JS.API.STREAM.INFO.KV_tasks' \
+	--allow-pubsub '$JS.API.STREAM.INFO.KV_tasks.>' \
+	--allow-pubsub '$JS.API.STREAM.CREATE.KV_tasks' \
+	--allow-pubsub '$JS.API.STREAM.CREATE.KV_tasks.>' \
 	--allow-pubsub '$JS.API.STREAM.INFO.KV_firmwareInstall' \
 	--allow-pubsub '$JS.API.STREAM.INFO.KV_firmwareInstall.>' \
 	--allow-pubsub '$JS.API.STREAM.CREATE.KV_firmwareInstall' \

--- a/templates/conditionorc-api-deployment.yaml
+++ b/templates/conditionorc-api-deployment.yaml
@@ -32,6 +32,8 @@ spec:
               mountPath: /etc/nats
               readOnly: true
           env:
+            - name: CONDITIONORC_OIDC_ENABLED
+              value: "{{ .Values.conditionorc.env.endpoints.conditionorc.authenticate }}"
             - name: CONDITIONORC_FLEETDB_ENABLE_SERVER_ENROLL
               value: "{{ .Values.conditionorc.enable_server_enroll }}"
             - name: CONDITIONORC_NATS_URL

--- a/templates/conditionorc-orchestrator-deployment.yaml
+++ b/templates/conditionorc-orchestrator-deployment.yaml
@@ -35,6 +35,8 @@ spec:
               mountPath: /etc/nats
               readOnly: true
           env:
+            - name: CONDITIONORC_OIDC_ENABLED
+              value: "{{ .Values.conditionorc.env.endpoints.conditionorc.authenticate }}"
             - name: CONDITIONORC_NATS_URL
               value: "{{ .Values.conditionorc.env.endpoints.nats.url }}"
             - name: CONDITIONORC_NATS_CONNECT_TIMEOUT

--- a/templates/flipflop-configmap.yaml
+++ b/templates/flipflop-configmap.yaml
@@ -12,6 +12,7 @@ data:
     store_kind: fleetdb
     events_broker_kind: nats
     nats:
+      kv_replication: 1
       app_name: flipflop
       # TODO: remove deprecated stream_urn_ns field
       stream_urn_ns: hollow-controllers

--- a/templates/flipflop-deployment.yaml
+++ b/templates/flipflop-deployment.yaml
@@ -30,7 +30,7 @@ spec:
            "--log-level",
            "debug",
            "--fault-injection",
-           "--replica-count=1",
+           "--dry-run",
            "--facility-code",
            "{{ .Values.flipflop.env.facility }}"
           ]


### PR DESCRIPTION
- Add CONDITIONORC_OIDC_ENABLED
- Add KV Tasks during nat spinup
- Update firmware.json to include newly required struct variables
- Change the README to reflect changes made to mctl
- Add convenient kubectl log make target
- Update flipflop config stuff